### PR TITLE
Include all stacks by default when importing images

### DIFF
--- a/actors/cloudbroker/CBGrid/.macros/page/images/1_images.py
+++ b/actors/cloudbroker/CBGrid/.macros/page/images/1_images.py
@@ -5,7 +5,7 @@ def main(j, args, params, tags, tasklet):
     modifier = j.portal.tools.html.htmlfactory.getPageModifierGridDataTables(page)
 
     stackid = args.getTag('stackid')
-    filters = dict()
+    filters = {'status': {'$ne': 'DESTROYED'}}
     if stackid:
         stack = models.Stack.get(stackid)
         filters['_id'] = {'$in': [img.id for img in stack.images]}

--- a/actors/cloudbroker/cloudbroker__iaas/methodclass/cloudbroker_iaas.py
+++ b/actors/cloudbroker/cloudbroker__iaas/methodclass/cloudbroker_iaas.py
@@ -197,7 +197,7 @@ class cloudbroker_iaas(BaseActor):
         gc = getGridClient(location, self.models)
         for storage in gc.storage.listVdiskStorages():
             for image in gc.storage.listImages(storage['id']):
-                localimage = self.models.Image.objects(referenceId=image['name']).first()
+                localimage = self.models.Image.objects(referenceId=image['name'], status__ne='DESTROYED').first()
                 if not localimage:
                     localimage = self.models.Image(
                         name=image['name'],
@@ -209,4 +209,5 @@ class cloudbroker_iaas(BaseActor):
                         type='Imported Image'
                     )
                     localimage.save()
+                    self.models.Stack.objects(location=location).update(add_to_set__images=localimage)
         return True

--- a/actors/cloudbroker/cloudbroker__image/methodclass/cloudbroker_image.py
+++ b/actors/cloudbroker/cloudbroker__image/methodclass/cloudbroker_image.py
@@ -98,7 +98,7 @@ class cloudbroker_image(BaseActor):
             raise exceptions.BadRequest("Image Unavailable, is it synced?")
         for stack in self.models.Stack.objects(images=image):
             if str(stack.id) not in enabledStacks:
-                stack.update(pull_images=image)
+                stack.update(pull__images=image)
             else:
                 enabledStacks.remove(str(stack.id))
 


### PR DESCRIPTION
The most common usecase is to use all images on all nodes so lets make
them available by default on all nodes.

This PR also fixes an issue when making an image unavailable from a
stack

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>