### PR TITLE
Don't return location api and apikey in location

### DIFF
--- a/actors/cloudapi/cloudapi__locations/methodclass/cloudapi_locations.py
+++ b/actors/cloudapi/cloudapi__locations/methodclass/cloudapi_locations.py
@@ -10,7 +10,7 @@ class cloudapi_locations(BaseActor):
         :return list with every element containing details of a location as a dict
         """
         results = []
-        for location in self.models.Location.objects:
+        for location in self.models.Location.objects.only('id', 'name'):
             results.append(location.to_dict())
         return results
 


### PR DESCRIPTION
In location listing do not return apikey and apiurl as this could be
abused.

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>